### PR TITLE
support for gzip stream

### DIFF
--- a/Debug/makefile
+++ b/Debug/makefile
@@ -4,6 +4,8 @@
 
 -include ../makefile.init
 
+
+
 RM := rm -rf
 
 # All of the sources participating in the build are defined here
@@ -45,6 +47,8 @@ endif
 
 # Add inputs and outputs from these tool invocations to the build variables 
 
+LIBS +=-lz
+
 # All Target
 all: SURVIVOR
 
@@ -52,7 +56,7 @@ all: SURVIVOR
 SURVIVOR: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: Cross G++ Linker'
-	g++  -o "SURVIVOR" $(OBJS) $(USER_OBJS) $(LIBS)
+	g++  -o $@ $(OBJS) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/src/GzipStream.h
+++ b/src/GzipStream.h
@@ -1,0 +1,123 @@
+
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2019 Pierre Lindenbaum @yokofakun Institut du Thorax France
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+#ifndef GZIP_STREAM
+#define GZIP_STREAM
+
+#include <sstream>
+#include <string>
+#include <iostream>
+#include <stdexcept>
+#include <zlib.h>
+#include <streambuf>
+#include <cstdlib>
+#include <cstring>
+#include <cassert>
+
+
+class GzipStreamBuf : public std::basic_streambuf<char>
+	{
+	private:
+		unsigned int buff_size;
+		char* buffer;
+		gzFile gzin;
+
+		void checkError()
+			{
+			int ret = 0;
+			const char* msg = ::gzerror(this->gzin,&ret);
+			if(ret==0) return;
+			if(msg==NULL)
+				{
+				throw std::runtime_error("GZLIB: I/O error");
+				}
+			else
+				{
+				throw std::runtime_error(msg);
+				}
+			}
+	
+
+
+
+		
+		void _init(const char* fname,unsigned int buff_size)
+			{
+			assert(buff_size>0);
+			this->gzin = ::gzopen(fname,"r");
+			if(this->gzin == NULL)
+				{
+				std::ostringstream msg;
+				msg << "File Parser: could not open file: " << fname << std::endl;
+				throw std::runtime_error(msg.str());
+				}
+
+			this->buff_size=buff_size;
+			this->buffer=new char[buff_size];
+		
+			setg(	(char*)&this->buffer[0],
+				(char*)&this->buffer[this->buff_size],
+				(char*)&this->buffer[this->buff_size]
+				);
+			
+			}
+		
+	
+	
+	public:
+		GzipStreamBuf(const char* fname)
+			{
+			_init(fname,BUFSIZ);
+			}
+			
+		virtual ~GzipStreamBuf()
+			{
+			if(gzin!=NULL) ::gzclose(this->gzin);
+			if(this->buffer!=NULL) delete [] this->buffer;
+			}
+		
+		virtual int underflow ( )
+			{
+			int nRead =0;
+			if(gzeof(this->gzin)) return EOF;
+			
+			if( ( nRead = ::gzread(this->gzin,this->buffer,this->buff_size) ) <= 0 ) {
+				checkError();
+				return EOF;
+				}
+
+			setg(	(char*)this->buffer,
+				(char*)&this->buffer[1],
+				(char*)&this->buffer[nRead+1]
+				);
+			
+			return this->buffer[0];
+			}
+	};
+
+
+
+#endif

--- a/src/vcfs/Merge_VCF.cpp
+++ b/src/vcfs/Merge_VCF.cpp
@@ -4,7 +4,7 @@
  *  Created on: Feb 12, 2015
  *      Author: fsedlaze
  */
-
+#include "../GzipStream.h"
 #include "Merge_VCF.h"
 
 //read in all the vcf filenames:
@@ -16,8 +16,8 @@ std::vector<std::string> parse_filename(std::string filename) {
 
 	myfile.open(filename.c_str(), std::ifstream::in);
 	if (!myfile.good()) {
-		std::cout << "File Parser: could not open file: " << filename.c_str() << std::endl;
-		exit(0);
+		std::cerr << "File Parser: could not open file: " << filename.c_str() << std::endl;
+		exit(EXIT_FAILURE);
 	}
 	myfile.getline(buffer, buffer_size);
 	while (!myfile.eof()) {
@@ -553,12 +553,12 @@ std::vector<strvcfentry> parse_vcf(std::string & filename, int min_svs) {
 	//char*buffer = new char[buffer_size];
 
 	std::string buffer;
-	std::ifstream myfile;
+	GzipStreamBuf gzbuf(filename.c_str());
+	std::istream myfile(&gzbuf);
 
-	myfile.open(filename.c_str(), std::ifstream::in);
 	if (!myfile.good()) {
-		std::cerr << "VCF Parser: could not open file: " << filename.c_str() << std::endl;
-		exit(1);
+		std::cerr << "VCF Parser: could not open file: " << filename.c_str() << " " << strerror(errno) << std::endl;
+		exit(EXIT_FAILURE);
 	}
 
 	std::vector<strvcfentry> calls;
@@ -804,7 +804,7 @@ std::vector<strvcfentry> parse_vcf(std::string & filename, int min_svs) {
 		}
 		getline(myfile, buffer);
 	}
-	myfile.close();
+	
 //std::cout << calls.size() << std::endl;
 	return calls;
 }
@@ -849,8 +849,8 @@ std::string get_header(std::vector<std::string> names) {
 
 	myfile.open(names[0].c_str(), std::ifstream::in);
 	if (!myfile.good()) {
-		std::cout << "Annotation Parser: could not open file: " << names[0].c_str() << std::endl;
-		exit(0);
+		std::cerr << "Annotation Parser: could not open file: " << names[0].c_str() << std::endl;
+		exit(EXIT_FAILURE);
 	}
 	std::string header;
 	myfile.getline(buffer, buffer_size);


### PR DESCRIPTION
This PR is related to https://github.com/fritzsedlazeck/SURVIVOR/issues/72

it adds a support for g-zipped stream for 'merge'

basically I created a subclass of streambuf that wrap the gzlib (https://www.zlib.net/manual.html) and I use this new class to initialize a istream that reads the vcf

I added  a library ` -lz`  in the makefile.

I don't have any unit test but it seems to merge with a mix of vcf+vcf.gz files.

I changed some message from 'cout' to 'cerr' and exit with failure (not `exit(0)` )
