### PR TITLE
fix buf in underflow

### DIFF
--- a/src/GzipStream.h
+++ b/src/GzipStream.h
@@ -111,7 +111,7 @@ class GzipStreamBuf : public std::basic_streambuf<char>
 
 			setg(	(char*)this->buffer,
 				(char*)&this->buffer[1],
-				(char*)&this->buffer[nRead+1]
+				(char*)&this->buffer[nRead]
 				);
 			
 			return this->buffer[0];


### PR DESCRIPTION
sorry I fixed a stupid bug in `underflow` that introduced an extra character.

ping @LinXialab that recently compiled from master.