### PR TITLE
streambuf/overflow shouln't advance the setg

### DIFF
--- a/src/GzipStream.h
+++ b/src/GzipStream.h
@@ -109,8 +109,8 @@ class GzipStreamBuf : public std::basic_streambuf<char>
 				return EOF;
 				}
 
-			setg(	(char*)this->buffer,
-				(char*)&this->buffer[1],
+			setg(	(char*)&this->buffer[0],
+				(char*)&this->buffer[0],
 				(char*)&this->buffer[nRead]
 				);
 			


### PR DESCRIPTION
sorry, there here is another small bug (to my defense the specification of std::streambuf is not clear :-/ )