### PR TITLE
Read SV Length from DEB if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+Debug/

--- a/src/convert/Convert_VCF_to_BED.cpp
+++ b/src/convert/Convert_VCF_to_BED.cpp
@@ -344,7 +344,12 @@ std::string print_entry_bed(strvcfentry & region) {
 	convert << ";END=";
 	convert << region.stop.pos;
 	convert << ";CIPOS=0,0;CIEND=0,0;SVLEN=";
-	convert << region.stop.pos - region.start.pos;
+    if(region.sv_len == -1){
+        convert << region.stop.pos - region.start.pos;
+    } else {
+        convert << region.sv_len;
+    }
+
 	convert << "\tGT\t.\/.";
 	return convert.str();
 }
@@ -369,6 +374,7 @@ void process_bed_file(std::string bedfile, std::string type, std::string output)
 		int count = 0;
 		strvcfentry region;
 		for (size_t i = 0; i < buffer_size && buffer[i] != '\0' && buffer[i] != '\n'; i++) {
+            region.sv_len = -1;
 			if (count == 0 && buffer[i] != '\t') {
 				region.start.chr += buffer[i];
 				region.stop.chr += buffer[i];
@@ -378,8 +384,12 @@ void process_bed_file(std::string bedfile, std::string type, std::string output)
 			}
 			if (count == 2 && buffer[i - 1] == '\t') {
 				region.stop.pos = atoi(&buffer[i]);
-				break;
 			}
+            if (count == 3 && buffer[i - 1] == '\t') {
+                region.sv_len = atoi(&buffer[i]);
+                break;
+            }
+
 			if (buffer[i] == '\t') {
 				count++;
 			}

--- a/src/convert/Convert_VCF_to_BED.cpp
+++ b/src/convert/Convert_VCF_to_BED.cpp
@@ -374,7 +374,7 @@ void process_bed_file(std::string bedfile, std::string type, std::string output)
 		int count = 0;
 		strvcfentry region;
 		for (size_t i = 0; i < buffer_size && buffer[i] != '\0' && buffer[i] != '\n'; i++) {
-            region.sv_len = -1;
+            region.sv_len = -0;
 			if (count == 0 && buffer[i] != '\t') {
 				region.start.chr += buffer[i];
 				region.stop.chr += buffer[i];
@@ -383,7 +383,7 @@ void process_bed_file(std::string bedfile, std::string type, std::string output)
 				region.start.pos = atoi(&buffer[i]) + 1;
 			}
 			if (count == 2 && buffer[i - 1] == '\t') {
-				region.stop.pos = atoi(&buffer[i]);
+				region.stop.pos = atoi(&buffer[i]) + 1;
 			}
             if (count == 3 && buffer[i - 1] == '\t') {
                 region.sv_len = atoi(&buffer[i]);

--- a/src/merge_vcf/combine_svs.cpp
+++ b/src/merge_vcf/combine_svs.cpp
@@ -696,7 +696,7 @@ void combine_calls_svs(std::string files, double max_dist, int min_support, int 
 				type = 5;
 			}
 
-			if (support >= min_support && len > min_svs) {
+			if (support >= min_support && len >= min_svs) {
 				print_entry_overlap(file, (*i), id);
 			}
 


### PR DESCRIPTION
Some callers will report start and end positions very similar (or the same) and still have the length of the SV greater than the difference of those. I added a small change so we can use the 4th column of the BED file in case it contains the size of the SVs.